### PR TITLE
Change the docker branch for releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: docker-agora
 
 on:
   push:
-    branches: [ "agora" ]
+    branches: [ "agora_v3.1.1" ]
 
 jobs:
 


### PR DESCRIPTION
Now the default project branch has been set to agora_v3.1.1 we should also push this branch release to dockerhub.