### PR TITLE
Revert "Do not log ready for merge before chain start"

### DIFF
--- a/beacon-chain/execution/check_transition_config.go
+++ b/beacon-chain/execution/check_transition_config.go
@@ -153,9 +153,6 @@ func (s *Service) logTtdStatus(ctx context.Context, ttd *uint256.Int) (bool, err
 	if latestTtd.Cmp(ttd.ToBig()) >= 0 {
 		return true, nil
 	}
-	if !s.chainStartData.Chainstarted {
-		return
-	}
 	log.WithFields(logrus.Fields{
 		"latestDifficulty":   latestTtd.String(),
 		"terminalDifficulty": ttd.ToBig().String(),


### PR DESCRIPTION
This reverts commit 59c2debc3803b4bef3853aac15d336a84775af77. It was not compiling due to a bug. On MacBook I was unable to test this. I will submit a new PR with a fix. This will fix the build until then.
