### PR TITLE
Enable docker build for PRs

### DIFF
--- a/cmd/beacon-chain/BUILD.bazel
+++ b/cmd/beacon-chain/BUILD.bazel
@@ -82,10 +82,8 @@ go_image_debug(
 container_bundle(
     name = "image_bundle_debug",
     images = {
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:latest-debug": ":image_debug",
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}-debug": ":image_debug",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:latest-debug": ":image_debug",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:{DOCKER_TAG}-debug": ":image_debug",
+        "bosagora/agora-cl-node:latest-debug": ":image_debug",
+        "bosagora/agora-cl-node:{DOCKER_TAG}-debug": ":image_debug",
     },
     tags = ["manual"],
     visibility = ["//beacon-chain:__pkg__"],
@@ -101,10 +99,8 @@ go_image_alpine(
 container_bundle(
     name = "image_bundle_alpine",
     images = {
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:latest-alpine": ":image_alpine",
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:latest-alpine": ":image_alpine",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
+        "bosagora/agora-cl-node:latest-alpine": ":image_alpine",
+        "bosagora/agora-cl-node:{DOCKER_TAG}-alpine": ":image_alpine",
     },
     tags = ["manual"],
     visibility = ["//beacon-chain:__pkg__"],

--- a/cmd/validator/BUILD.bazel
+++ b/cmd/validator/BUILD.bazel
@@ -77,10 +77,8 @@ go_image_debug(
 container_bundle(
     name = "image_bundle_debug",
     images = {
-        "gcr.io/prysmaticlabs/prysm/validator:latest-debug": ":image_debug",
-        "gcr.io/prysmaticlabs/prysm/validator:{DOCKER_TAG}-debug": ":image_debug",
-        "index.docker.io/prysmaticlabs/prysm-validator:latest-debug": ":image_debug",
-        "index.docker.io/prysmaticlabs/prysm-validator:{DOCKER_TAG}-debug": ":image_debug",
+        "bosagora/agora-cl-validator:latest-debug": ":image_debug",
+        "bosagora/agora-cl-validator:{DOCKER_TAG}-debug": ":image_debug",
     },
     tags = ["manual"],
     visibility = ["//validator:__pkg__"],
@@ -96,10 +94,8 @@ go_image_alpine(
 container_bundle(
     name = "image_bundle_alpine",
     images = {
-        "gcr.io/prysmaticlabs/prysm/validator:latest-alpine": ":image_alpine",
-        "gcr.io/prysmaticlabs/prysm/validator:{DOCKER_TAG}-alpine": ":image_alpine",
-        "index.docker.io/prysmaticlabs/prysm-validator:latest-alpine": ":image_alpine",
-        "index.docker.io/prysmaticlabs/prysm-validator:{DOCKER_TAG}-alpine": ":image_alpine",
+        "bosagora/agora-cl-validator:latest-alpine": ":image_alpine",
+        "bosagora/agora-cl-validator:{DOCKER_TAG}-alpine": ":image_alpine",
     },
     tags = ["manual"],
     visibility = ["//validator:__pkg__"],


### PR DESCRIPTION
As it is not possible to build on the MacBook this enables testing an update to agora-cl using the pushed debug docker image.