### PR TITLE
Add Github workflow file for debug build

### DIFF
--- a/.github/workflows/docker_debug.yml
+++ b/.github/workflows/docker_debug.yml
@@ -1,0 +1,39 @@
+name: docker-agora
+
+on:
+  push:
+    branches: [ 'debug' ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      HAVE_DOCKERHUB_SECRET: ${{ secrets.DHUB_TOKEN != '' && secrets.DHUB_USER != '' }}
+
+    steps:
+    - name: Install packages
+      run: sudo apt-get update && sudo apt-get install -y cmake git libssl-dev libgmp-dev libtinfo5 libprotobuf-dev
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      id: login
+      # If the user set up those variable, it's upstream or (s)he wants the push to happen
+      # Otherwise, it might just be someone pushing to their fork, in which case we still
+      # want to build as it's useful to test a release before upstreaming it.
+      if: env.HAVE_DOCKERHUB_SECRET
+      with:
+        username: ${{ secrets.DHUB_USER }}
+        password: ${{ secrets.DHUB_TOKEN }}
+
+    - uses: actions/checkout@v2
+
+    - name: Build and push beacon-chain
+      run: bazel run //cmd/beacon-chain:push_images_debug --config=release
+
+    - name: Build and push validator
+      run: bazel run //cmd/validator:push_images_debug --config=release
+
+    - name: Build and push bootnode
+      run: bazel run //tools/bootnode:push_images_debug --config=release

--- a/cmd/beacon-chain/BUILD.bazel
+++ b/cmd/beacon-chain/BUILD.bazel
@@ -72,18 +72,10 @@ container_bundle(
     visibility = ["//beacon-chain:__pkg__"],
 )
 
-go_image_debug(
-    name = "image_debug",
-    image = ":image",
-    tags = ["manual"],
-    visibility = ["//beacon-chain:__pkg__"],
-)
-
 container_bundle(
     name = "image_bundle_debug",
     images = {
-        "bosagora/agora-cl-node:latest-debug": ":image_debug",
-        "bosagora/agora-cl-node:{DOCKER_TAG}-debug": ":image_debug",
+        "bosagora/agora-cl-node:debug": ":image_with_creation_time",
     },
     tags = ["manual"],
     visibility = ["//beacon-chain:__pkg__"],

--- a/cmd/validator/BUILD.bazel
+++ b/cmd/validator/BUILD.bazel
@@ -67,18 +67,10 @@ container_bundle(
     visibility = ["//validator:__pkg__"],
 )
 
-go_image_debug(
-    name = "image_debug",
-    image = ":image",
-    tags = ["manual"],
-    visibility = ["//validator:__pkg__"],
-)
-
 container_bundle(
     name = "image_bundle_debug",
     images = {
-        "bosagora/agora-cl-validator:latest-debug": ":image_debug",
-        "bosagora/agora-cl-validator:{DOCKER_TAG}-debug": ":image_debug",
+        "bosagora/agora-cl-validator:debug": ":image_with_creation_time",
     },
     tags = ["manual"],
     visibility = ["//validator:__pkg__"],


### PR DESCRIPTION
If push is made to branch named debug then Guthub actions will build the docker images and push to Dockerhub with tags:
`bosagora/agora-cl-node:debug` and `bosagora/agora-cl-validator:debug`