### PR TITLE
Enable docker debug build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: docker-agora
 
 on:
   push:
-    branches: [ "agora_v3.1.1" ]
+    branches: [ "agora" ]
 
 jobs:
 

--- a/tools/bootnode/BUILD.bazel
+++ b/tools/bootnode/BUILD.bazel
@@ -62,6 +62,20 @@ docker_push(
     tags = ["manual"],
 )
 
+container_bundle(
+    name = "image_bundle_debug",
+    images = {
+        "bosagora/agora-cl-bootnode:debug": ":image",
+    },
+    tags = ["manual"],
+)
+
+docker_push(
+    name = "push_images_debug",
+    bundle = ":image_bundle",
+    tags = ["manual"],
+)
+
 go_test(
     name = "go_default_test",
     srcs = ["bootnode_test.go"],


### PR DESCRIPTION
On merge to agora we should build the new docker images for testing and push to Dockerhub.
