### PR TITLE
Fix the import path for agora

### DIFF
--- a/agora/BUILD.bazel
+++ b/agora/BUILD.bazel
@@ -3,7 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["block_rewards.go"],
-    importpath = "github.com/prysmaticlabs/prysm/agora",
+    importpath = "github.com/prysmaticlabs/prysm/v3/agora",
     visibility = ["//visibility:public"],
     deps = [
         "//config/params:go_default_library",

--- a/beacon-chain/core/altair/attestation.go
+++ b/beacon-chain/core/altair/attestation.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/agora"
+	"github.com/prysmaticlabs/prysm/v3/agora"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/time"

--- a/beacon-chain/core/altair/block.go
+++ b/beacon-chain/core/altair/block.go
@@ -3,8 +3,8 @@ package altair
 import (
 	"context"
 
-	"github.com/prysmaticlabs/prysm/agora"
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v3/agora"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/signing"
 	p2pType "github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p/types"

--- a/beacon-chain/core/altair/epoch_precompute.go
+++ b/beacon-chain/core/altair/epoch_precompute.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/agora"	
+	"github.com/prysmaticlabs/prysm/v3/agora"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/epoch/precompute"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/time"


### PR DESCRIPTION
The `agora` module was added before the update to use Prysm v3. If you want to use `go lang` to build or run during development then the import requires the v3 in the path.