### PR TITLE
Update log message for insecure gRPC server

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -164,9 +164,8 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		}
 		opts = append(opts, grpc.Creds(creds))
 	} else {
-		log.Warn("You are using an insecure gRPC server. If you are running your beacon node and " +
-			"validator on the same machines, you can ignore this message. If you want to know " +
-			"how to enable secure connections, see: https://docs.prylabs.network/docs/prysm-usage/secure-grpc")
+		log.Info("You are using an insecure gRPC server. This is expected when running your beacon node and " +
+			"validator on the same machine as recommended.")
 	}
 	s.grpcServer = grpc.NewServer(opts...)
 


### PR DESCRIPTION
This is another warning that is also not required to be logged as warning as it is recommended.
