### PR TITLE
Do not use `isfromBadIP`

### DIFF
--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -335,7 +335,7 @@ func (p *Status) IsBad(pid peer.ID) bool {
 
 // isBad is the lock-free version of IsBad.
 func (p *Status) isBad(pid peer.ID) bool {
-	return p.isfromBadIP(pid) || p.scorers.IsBadPeerNoLock(pid)
+	return p.scorers.IsBadPeerNoLock(pid)
 }
 
 // NextValidTime gets the earliest possible time it is to contact/dial


### PR DESCRIPTION
The same IP is supposed to be blocked if you connect more than five times

Remove IP Tracking
It would be nice to consider the addition of this function when the number of nodes in the BOSagora network increases in the future.